### PR TITLE
Remove problematic hiding scripts

### DIFF
--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -18,6 +18,12 @@ maybe_set_prop vendor.boot.mode recovery unknown
 
 resetprop --delete ro.build.selinux
 
+# SELinux permissive | use toybox to protect stat access time
+if [[ "$(toybox cat /sys/fs/selinux/enforce)" == "0" ]]; then
+    chmod 640 /sys/fs/selinux/enforce
+    chmod 440 /sys/fs/selinux/policy
+fi
+
 # Late props which must be set after boot_completed
 {
     until [[ "$(getprop sys.boot_completed)" == "1" ]]; do

--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -16,17 +16,7 @@ maybe_set_prop ro.bootmode recovery unknown
 maybe_set_prop ro.boot.mode recovery unknown
 maybe_set_prop vendor.boot.mode recovery unknown
 
-# MIUI cross-region flash
-maybe_set_prop ro.boot.hwc CN GLOBAL
-maybe_set_prop ro.boot.hwcountry China GLOBAL
-
 resetprop --delete ro.build.selinux
-
-# SELinux permissive
-if [[ "$(cat /sys/fs/selinux/enforce)" == "0" ]]; then
-    chmod 640 /sys/fs/selinux/enforce
-    chmod 440 /sys/fs/selinux/policy
-fi
 
 # Late props which must be set after boot_completed
 {


### PR DESCRIPTION
Issue 1:
According to user reports, setting Xiaomi region props will break booting. This may be caused by some framework internal check. As this is for cross-region flash which is not used for hide, remove it.

Issue 2:
We have seen applications using new ways to detect abnormal environments. One of them is /sys/fs/selinux, as this dir has +x permission for all users. This makes running 'stat' command on nodes possible.

Here we have a problem. Running busybox's 'cat' on files will change its access time (not seen on toybox's 'cat' though). This
can be easily detected by 'stat /sys/fs/selinux', seeing access time which does not start with '1970-01-01'.

This check is actually useless at all. Chmod +644 the node will make 'stat' impossible, thus leading to more detection. Thus remove the check. This method is seen on multiple apps in recent research.